### PR TITLE
Fix/correccion select

### DIFF
--- a/app/src/main/java/com/example/recoapp/RegisterActivity.kt
+++ b/app/src/main/java/com/example/recoapp/RegisterActivity.kt
@@ -23,7 +23,7 @@ class RegisterActivity : AppCompatActivity() {
 
         db = AppDatabase.getDatabase(this)
 
-        val typeSpinner = findViewById<AutoCompleteTextView>(R.id.spinnerTipo)
+        val typeSpinner = findViewById<Spinner>(R.id.spinnerTipo)
         val quantityEditText = findViewById<EditText>(R.id.editCantidad)
         val locationEditText = findViewById<EditText>(R.id.editUbicacion)
         val dateEditText = findViewById<EditText>(R.id.editFecha)
@@ -37,13 +37,13 @@ class RegisterActivity : AppCompatActivity() {
             getString(R.string.organic),
             getString(R.string.other)
         )
-        typeSpinner.setAdapter(
-            ArrayAdapter(
-                this,
-                android.R.layout.simple_dropdown_item_1line,
-                wasteTypes
-            )
+        val adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_item,
+            wasteTypes
         )
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        typeSpinner.adapter = adapter
 
         val calendar = Calendar.getInstance()
         val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
@@ -62,7 +62,7 @@ class RegisterActivity : AppCompatActivity() {
         }
 
         saveButton.setOnClickListener {
-            val type = typeSpinner.text.toString()
+            val type = typeSpinner.selectedItem?.toString() ?: ""
             val quantityStr = quantityEditText.text.toString()
             val location = locationEditText.text.toString()
             val comment = commentsEditText.text.toString()

--- a/app/src/main/java/com/example/recoapp/ReportsActivity.kt
+++ b/app/src/main/java/com/example/recoapp/ReportsActivity.kt
@@ -13,6 +13,7 @@ import java.util.*
 class ReportsActivity : AppCompatActivity() {
 
     private lateinit var db: AppDatabase
+    private lateinit var wasteTypes: Array<String>
     private var startDate: Date? = null
     private var endDate: Date? = null
 
@@ -22,29 +23,33 @@ class ReportsActivity : AppCompatActivity() {
 
         db = AppDatabase.getDatabase(this)
 
-        val typeSpinner = findViewById<AutoCompleteTextView>(R.id.spinnerTypeFilter)
+        val typeSpinner = findViewById<Spinner>(R.id.spinnerReport)
         val startDateEditText = findViewById<EditText>(R.id.editStartDate)
         val endDateEditText = findViewById<EditText>(R.id.editEndDate)
         val generateButton = findViewById<Button>(R.id.btnGenerateReport)
         val resultTextView = findViewById<TextView>(R.id.textReportResult)
 
-        val wasteTypes = arrayOf(
-            getString(R.string.all_types),
+        wasteTypes = arrayOf(
             getString(R.string.plastic),
             getString(R.string.paper),
             getString(R.string.glass),
             getString(R.string.organic),
             getString(R.string.other)
         )
-        typeSpinner.setAdapter(
-            ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, wasteTypes)
+
+        val adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_item,
+            wasteTypes
         )
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        typeSpinner.adapter = adapter
 
         startDateEditText.setOnClickListener { showDatePickerDialog(it as EditText, true) }
         endDateEditText.setOnClickListener { showDatePickerDialog(it as EditText, false) }
 
         generateButton.setOnClickListener {
-            val type = typeSpinner.text.toString()
+            val type = typeSpinner.selectedItem?.toString()
             if (startDate != null && endDate != null) {
                 lifecycleScope.launch {
                     val selectedType = if (type == getString(R.string.all_types)) null else type

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -9,17 +9,17 @@
         android:orientation="vertical"
         android:padding="24dp">
 
-        <com.google.android.material.textfield.TextInputLayout
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Tipo de residuo">
+            android:text="Tipo de residuo"
+            android:paddingBottom="4dp" />
 
-            <AutoCompleteTextView
-                android:id="@+id/spinnerTipo"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:inputType="none" />
-        </com.google.android.material.textfield.TextInputLayout>
+        <Spinner
+            android:id="@+id/spinnerTipo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:prompt="@string/hint_waste_type" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_reports.xml
+++ b/app/src/main/res/layout/activity_reports.xml
@@ -11,18 +11,17 @@
         android:text="@string/filters_title"
         android:textAppearance="?attr/textAppearanceHeadline6" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:hint="@string/hint_waste_type_optional">
-
-        <AutoCompleteTextView
-            android:id="@+id/spinnerTypeFilter"
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="none" />
-    </com.google.android.material.textfield.TextInputLayout>
+            android:text="Tipo de residuo"
+            android:paddingBottom="4dp" />
+
+        <Spinner
+            android:id="@+id/spinnerReport"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:prompt="@string/hint_waste_type" />
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Esta pull request refactoriza la interfaz de usuario de selección de tipo de residuo tanto en las funciones de registro como en las de informes, sustituyendo la implementación anterior de `AutoCompleteTextView` por un widget `Spinner` más adecuado. Los cambios afectan tanto a los archivos de actividad de Kotlin como a los archivos de diseño XML correspondientes, lo que mejora la coherencia y la experiencia del usuario.

**Reestructuración de la interfaz de usuario: selección del tipo de residuo**

* Se ha sustituido `AutoCompleteTextView` por `Spinner` para la selección del tipo de residuo en las pantallas de registro (`activity_register.xml`, `RegisterActivity.kt`) e informes (`activity_reports.xml`, `ReportsActivity.kt`), actualizando tanto el diseño como la lógica de la actividad para utilizar el nuevo widget. 

* Se ha actualizado la configuración del adaptador en ambas actividades para utilizar `ArrayAdapter` con los diseños `simple_spinner_item` y `simple_spinner_dropdown_item`, lo que garantiza un comportamiento adecuado del menú desplegable para el `Spinner`. 

**Actualizaciones de la lógica del código**

* Se ha cambiado la lógica para recuperar el tipo de residuo seleccionado de `typeSpinner.text.toString()` a `typeSpinner.selectedItem?.toString()` en ambas actividades, para que coincida con la nueva implementación de `Spinner`.

* En `ReportsActivity.kt`, se ha convertido `wasteTypes` en una propiedad de la actividad para facilitar el acceso y la coherencia.

<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/fe617ee1-8827-4e59-90b9-1768d6e6886f" />
<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/549ad10f-74ae-42ea-8e70-0f527cdeee26" />